### PR TITLE
Specify Start Times

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ __Backlog__
 6. Notify my wife of other events in which she may be interested
 7. Implement the `EncryptedFileReader` to read encrypted data instead of storing in plaintext files
 8. Implement a way to check the health status of the application without waiting for the scheduled health check notification
+9. ~~Implement a way to begin queries after a delay specified in application properties rather than immediately kicking them off upon application start~~

--- a/src/com/john/application/HealthChecker.java
+++ b/src/com/john/application/HealthChecker.java
@@ -25,12 +25,14 @@ public class HealthChecker {
 	
 	/**
 	 * Schedules a notification to be sent to every admin recipient using the provided
-	 * <code>ScheduledExecutorService</code>. It starts after an initial delay of 1 minute.
+	 * <code>ScheduledExecutorService</code>. It starts after an initial delay as specified in
+	 * application.properties, or 1 minute if none is specified.
 	 * */
 	public static void start(ScheduledExecutorService executor) {
 		if (ApplicationPropertyProvider.getBooleanProperty(Property.HEALTHCHECKER_ENABLED)) {
 			final long frequency = ApplicationPropertyProvider.getLongProperty(Property.HEALTHCHECKER_FREQUENCY);
-			log.info(String.format("Starting automatic health checks with a frequency of %d minutes", frequency));
+			final long initialDelay = ApplicationPropertyProvider.getLongProperty(Property.HEALTHCHECKER_INITIAL_DELAY, 1);
+			log.info(String.format("Starting automatic health checks with a frequency of %d minute(s)", frequency));
 			executor.scheduleAtFixedRate(() -> {
 				try {
 					log.info("The health checker is now running in Thread #" + Thread.currentThread().getId());
@@ -52,7 +54,7 @@ public class HealthChecker {
 							"Exception was caught during the scheduled health check: [%s]. The health check will try again in %d minutes.",
 							e.getMessage(), frequency));
 				}
-			}, 1, frequency, TimeUnit.MINUTES);
+			}, initialDelay, frequency, TimeUnit.MINUTES);
 		} else {
 			log.warning("Health checks are disabled");
 		}

--- a/src/com/john/application/StaviSearcherApplication.java
+++ b/src/com/john/application/StaviSearcherApplication.java
@@ -27,7 +27,8 @@ public class StaviSearcherApplication {
 		ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
 		
 		// schedule main query operation
-		executor.scheduleAtFixedRate(new StavisQueryOperator(), 0,
+		executor.scheduleAtFixedRate(new StavisQueryOperator(),
+				ApplicationPropertyProvider.getLongProperty(Property.QUERY_INITIAL_DELAY, 0),
 				ApplicationPropertyProvider.getLongProperty(Property.QUERY_FREQUENCY_MINUTES), TimeUnit.MINUTES);
 		log.info("Stavi's Query Operator has been scheduled with the executor");
 		

--- a/src/com/john/utils/ApplicationPropertyProvider.java
+++ b/src/com/john/utils/ApplicationPropertyProvider.java
@@ -31,16 +31,41 @@ public final class ApplicationPropertyProvider {
 		return APP_PROPERTIES.getProperty(property.toString());
 	}
 	
+	public static String getProperty(Property property, String defaultValue) {
+		if (hasProperty(property)) {
+			return getProperty(property);
+		}
+		return defaultValue;
+	}
+	
 	public static int getIntProperty(Property property) {
 		return Integer.parseInt(APP_PROPERTIES.getProperty(property.toString()));
+	}
+	
+	public static int getIntProperty(Property property, int defaultValue) {
+		if (hasProperty(property)) {
+			return getIntProperty(property);
+		}
+		return defaultValue;
 	}
 	
 	public static long getLongProperty(Property property) {
 		return Long.parseLong(APP_PROPERTIES.getProperty(property.toString()));
 	}
 	
+	public static long getLongProperty(Property property, long defaultValue) {
+		if (hasProperty(property)) {
+			return getLongProperty(property);
+		}
+		return defaultValue;
+	}
+	
 	public static boolean getBooleanProperty(Property property) {
 		return Boolean.parseBoolean(APP_PROPERTIES.getProperty(property.toString()));
+	}
+	
+	public static boolean hasProperty(Property property) {
+		return APP_PROPERTIES.containsKey(property.toString());
 	}
 	
 	public static enum Property {
@@ -48,6 +73,7 @@ public final class ApplicationPropertyProvider {
 		PROD("prod"),
 		QUERY_MAX_DAYS("query.maxdays"),
 		QUERY_FREQUENCY_MINUTES("query.frequency"),
+		QUERY_INITIAL_DELAY("query.initialdelay"),
 		QUERY_KEYWORD("query.keyword"),
 		CALENDAR_ID("calendar.id"),
 		NOTIFICATIONS_ENABLED("notifications.enabled"),
@@ -61,6 +87,7 @@ public final class ApplicationPropertyProvider {
 		LOGGING_ROTATION_PREFIX("logging.rotation.prefix"),
 		HEALTHCHECKER_ENABLED("healthchecker.enabled"),
 		HEALTHCHECKER_FREQUENCY("healthchecker.frequency"),
+		HEALTHCHECKER_INITIAL_DELAY("healthchecker.initialdelay"),
 		HEALTHCHECKER_SUBJECT("healthchecker.subject"),
 		HEALTHCHECKER_MESSAGE("healthchecker.message");
 		


### PR DESCRIPTION
- Added the ability to specify an initial delay for both the query and health check operations. This allows both operations to kick off at predetermined future times instead of once the application starts up 
- Added 2 new properties to the `ApplicationPropertyProvider`
- Added overloaded methods to the `ApplicationPropertyProvider` to allow caller to specify default property values if the property is not available