### PR TITLE
Cache Secrets based on runtime argument

### DIFF
--- a/src/com/john/utils/providers/ApplicationPropertyProvider.java
+++ b/src/com/john/utils/providers/ApplicationPropertyProvider.java
@@ -15,8 +15,8 @@ public final class ApplicationPropertyProvider {
 	
 	static {
 		APP_PROPERTIES = new Properties();
-		try {			
-			APP_PROPERTIES.load(new FileInputStream("./resources/application.properties"));
+		try (FileInputStream fis = new FileInputStream("./resources/application.properties")) {			
+			APP_PROPERTIES.load(fis);
 		} catch (IOException e) {
 			log.severe("Failed to load application properties");
 			throw new RuntimeException(e.getMessage());

--- a/src/com/john/utils/providers/RuntimeArgumentProvider.java
+++ b/src/com/john/utils/providers/RuntimeArgumentProvider.java
@@ -75,7 +75,8 @@ public final class RuntimeArgumentProvider {
 	}
 	
 	public static enum RuntimeArgument {
-		SECRETS_LOCATION("secrets-location");
+		SECRETS_LOCATION("secrets-location"),
+		CACHE_SECRETS("cache-secrets");
 		
 		private final String value;
 		private RuntimeArgument(String value) {


### PR DESCRIPTION
- If "--cache-secrets=true" is provided as a runtime argument, the `SecretProvider` will cache all secrets it finds when first asked for a secret, and all subsequent requests will read from the cache
- Closed the `FileInputStream` instances in both `SecretProvider` and `ApplicationPropertyProvider` to prevent memory leaks and prevent locked files by the OS