### PR TITLE
Additional secrets options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ __Backlog__
 7. ~~Implement the `EncryptedFileReader` to read encrypted data instead of storing in plaintext files~~
 8. Implement a way to check the health status of the application without waiting for the scheduled health check notification
 9. ~~Implement a way to begin queries after a delay specified in application properties rather than immediately kicking them off upon application start~~
+10. Create a single store for all properties instead of relying on different providers depending on how the property was provided to the application

--- a/src/com/john/utils/Utils.java
+++ b/src/com/john/utils/Utils.java
@@ -36,9 +36,6 @@ public class Utils {
 	
 	public static boolean deleteFile(String filePath) {
 		File file = new File(filePath);
-		if (file.exists()) {
-			return file.delete();
-		}
-		return false;
+		return file.exists() && file.delete();
 	}
 }

--- a/src/com/john/utils/Utils.java
+++ b/src/com/john/utils/Utils.java
@@ -1,5 +1,6 @@
 package com.john.utils;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.logging.Logger;
 
@@ -31,5 +32,13 @@ public class Utils {
 		int saltLength = SecretProvider.getIntSecret(Secret.SALTING_STRATEGY_LENGTH);
 		String saltingComposition = SecretProvider.getSecret(Secret.SALTING_STRATEGY_COMPOSITION);
 		return SaltingStrategy.getStrategy(Arrays.asList(saltingComposition.split(",")), saltLength);
+	}
+	
+	public static boolean deleteFile(String filePath) {
+		File file = new File(filePath);
+		if (file.exists()) {
+			return file.delete();
+		}
+		return false;
 	}
 }

--- a/src/com/john/utils/providers/RuntimeArgumentProvider.java
+++ b/src/com/john/utils/providers/RuntimeArgumentProvider.java
@@ -76,7 +76,9 @@ public final class RuntimeArgumentProvider {
 	
 	public static enum RuntimeArgument {
 		SECRETS_LOCATION("secrets-location"),
-		CACHE_SECRETS("cache-secrets");
+		CACHE_SECRETS("cache-secrets"),
+		EAGER_LOAD_SECRETS("eager-load-secrets"),
+		DELETE_SECRETS_ON_LOAD("delete-secrets-on-load");
 		
 		private final String value;
 		private RuntimeArgument(String value) {


### PR DESCRIPTION
- Added `--eager-load-secrets` runtime argument to support loading secrets file upon application initialization instead of waiting for the first secret to be requested
- Added `--delete-secrets-on-load` runtime argument to support programmatic deletion of the secrets properties file upon successful loading of secrets
-  Added backlog item #10 to README.md